### PR TITLE
fixed CI not working with deprecated package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,17 +4,16 @@ on:
   release:
     types:
       - released
-  pull_request:
 
 jobs:
   publish:
-    name: Build & Publish to Crates.io
+    name: Publish to Crates.io
     runs-on: ubuntu-latest
     steps:
       - name: Clean variable
         id: version
         run: |
-          TAG="v3.2.1"
+          TAG="${{ github.event.release.tag_name }}"
           echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -30,8 +29,6 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: cat Cargo.toml
       - uses: katyo/publish-crates@v2
-        if: github.event_name == 'push'
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Replaced [ciiiii/toml-editor](https://github.com/ciiiii/toml-editor) as it is not working for a custom pip package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Improved the publish workflow by setting up Python and using `toml-cli` for version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->