### PR TITLE
Fixed issues in `lib` migration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,3 +32,4 @@ jobs:
       - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          args: "--allow-dirty"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
+#![doc = include_str!("../README.md")]
+
 pub mod context;
 pub mod error;
-
-#[doc = include_str!("../README.md")]
-
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
Fixed some issues I didn't handle when migrating to a library.

- added `allow-dirty` to the library being pushed (as the version is updated)
- removed unused `main`